### PR TITLE
Fix progress callback for file generation

### DIFF
--- a/app/step8/page.tsx
+++ b/app/step8/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import { useProjectStore } from "@/lib/store"
 import { StepIndicator } from "@/components/step-indicator"
 import { FileGeneration } from "@/components/file-generation"
+import type { DocumentDetails } from "@/lib/types"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -188,6 +189,7 @@ export default function Step8Page() {
         <FileGeneration
           template={template}
           designTemplate={designTemplate}
+          documentDetails={documentDetails}
           recipients={recipients}
           logoUrl={logoFile?.url}
         />

--- a/components/file-generation.tsx
+++ b/components/file-generation.tsx
@@ -28,16 +28,17 @@ import {
   type GeneratedFile,
   type GenerationProgress,
 } from "@/lib/file-generator"
-import type { DocumentTemplate, Recipient } from "@/lib/types"
+import type { DocumentTemplate, Recipient, DocumentDetails } from "@/lib/types"
 
 interface FileGenerationProps {
   template: DocumentTemplate
   designTemplate: any
+  documentDetails: DocumentDetails
   recipients: Recipient[]
   logoUrl?: string | null
 }
 
-export function FileGeneration({ template, designTemplate, recipients, logoUrl }: FileGenerationProps) {
+export function FileGeneration({ template, designTemplate, documentDetails, recipients, logoUrl }: FileGenerationProps) {
   const [fileType, setFileType] = useState<"pdf" | "png" | "jpg">("pdf")
   const [isGenerating, setIsGenerating] = useState(false)
   const [generatedFiles, setGeneratedFiles] = useState<GeneratedFile[]>([])
@@ -61,7 +62,8 @@ export function FileGeneration({ template, designTemplate, recipients, logoUrl }
     })
 
     try {
-      const files = await generateAllFiles(template, designTemplate, recipients, fileType, logoUrl, setProgress)
+      const options = { format: fileType } as const
+      const files = await generateAllFiles(recipients, documentDetails, options, setProgress)
 
       setGeneratedFiles(files)
     } catch (error) {


### PR DESCRIPTION
## Summary
- wire up FileGeneration to use document details
- pass document details from Step8 page

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688877629f20832e9cb8a7c0a806221f