### PR TITLE
Fix progress naming

### DIFF
--- a/components/file-generation.tsx
+++ b/components/file-generation.tsx
@@ -55,10 +55,11 @@ export function FileGeneration({ template, designTemplate, documentDetails, reci
     setError("")
     setGeneratedFiles([])
     setProgress({
-      current: 0,
       total: recipients.length,
-      currentRecipient: "",
+      completed: 0,
+      current: "",
       status: "preparing",
+      errors: [],
     })
 
     try {
@@ -102,7 +103,7 @@ export function FileGeneration({ template, designTemplate, documentDetails, reci
 
   const getProgressPercentage = () => {
     if (!progress) return 0
-    return (progress.current / progress.total) * 100
+    return (progress.completed / progress.total) * 100
   }
 
   const getStatusMessage = () => {
@@ -112,11 +113,11 @@ export function FileGeneration({ template, designTemplate, documentDetails, reci
       case "preparing":
         return "파일 생성 준비 중..."
       case "generating":
-        return `${progress.currentRecipient} 파일 생성 중... (${progress.current}/${progress.total})`
+        return `${progress.current} 파일 생성 중... (${progress.completed}/${progress.total})`
       case "completed":
         return `모든 파일 생성 완료! (${progress.total}개)`
       case "error":
-        return progress.error || "오류 발생"
+        return progress.errors.join(", ") || "오류 발생"
       default:
         return ""
     }
@@ -224,11 +225,11 @@ export function FileGeneration({ template, designTemplate, documentDetails, reci
               <div className="text-center text-sm text-gray-600">{getStatusMessage()}</div>
               <div className="grid md:grid-cols-3 gap-4 text-sm">
                 <div className="text-center">
-                  <div className="font-medium text-blue-600">{progress.current}</div>
+                  <div className="font-medium text-blue-600">{progress.completed}</div>
                   <div className="text-gray-500">완료</div>
                 </div>
                 <div className="text-center">
-                  <div className="font-medium text-gray-600">{progress.total - progress.current}</div>
+                  <div className="font-medium text-gray-600">{progress.total - progress.completed}</div>
                   <div className="text-gray-500">대기</div>
                 </div>
                 <div className="text-center">


### PR DESCRIPTION
## Summary
- keep `completed` for count and `current` for recipient
- display progress using the unified shape

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688880ed77cc832e90dec93b56732f30