### PR TITLE
Use admin store key in AI revision

### DIFF
--- a/app/step6/page.tsx
+++ b/app/step6/page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { useProjectStore } from "@/lib/store"
+import { useAdminStore } from "@/lib/admin-store"
 import { StepIndicator } from "@/components/step-indicator"
 import { AIRevision } from "@/components/ai-revision"
 import { Button } from "@/components/ui/button"
@@ -17,14 +18,9 @@ export default function Step6Page() {
     useProjectStore()
 
   const [revisedTemplate, setRevisedTemplate] = useState<DocumentTemplate | null>(null)
-  const [apiKey, setApiKey] = useState("")
 
-  useEffect(() => {
-    const savedApiKey = localStorage.getItem("openai-api-key")
-    if (savedApiKey) {
-      setApiKey(savedApiKey)
-    }
-  }, [])
+  const { apiKey: storedApiKey } = useAdminStore()
+  const apiKey = storedApiKey || (typeof window !== "undefined" ? localStorage.getItem("openai-api-key") || "" : "")
 
   const handleRevisionComplete = (newTemplate: DocumentTemplate) => {
     setRevisedTemplate(newTemplate)


### PR DESCRIPTION
## Summary
- source API key from `useAdminStore` in step 6
- fallback to `localStorage` for legacy keys

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688880f8b2d4832e9876a20589971d57